### PR TITLE
Add reusable workflow for common code

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+---
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/test-alpha.yml
+++ b/.github/workflows/test-alpha.yml
@@ -8,78 +8,9 @@ on:
     - cron: 0 1 * * *
 
 jobs:
-    test:
-        runs-on: ubuntu-latest
-        strategy:
-            max-parallel: 2
-            matrix:
-              projects: [
-                  "https://github.com/defold/extension-spine/archive/master.zip",
-                  #"https://github.com/defold/extension-rive/archive/master.zip",
-                  "https://github.com/defold/extension-adinfo/archive/master.zip",
-                  "https://github.com/defold/extension-admob/archive/master.zip",
-                  "https://github.com/defold/extension-camera/archive/master.zip",
-                  "https://github.com/defold/extension-facebook/archive/master.zip",
-                  "https://github.com/defold/extension-fbinstant/archive/master.zip",
-                  "https://github.com/defold/extension-firebase/archive/master.zip",
-                  "https://github.com/defold/extension-firebase-analytics/archive/master.zip",
-                  "https://github.com/defold/extension-firebase-remoteconfig/archive/master.zip",
-                  "https://github.com/defold/extension-googleplayinstant/archive/master.zip",
-                  "https://github.com/defold/extension-gpgs/archive/master.zip",
-                  "https://github.com/defold/extension-html5/archive/master.zip",
-                  "https://github.com/defold/extension-iac/archive/master.zip",
-                  "https://github.com/defold/extension-iap/archive/master.zip",
-                  "https://github.com/defold/extension-kaiads/archive/main.zip",
-                  "https://github.com/defold/extension-kaios/archive/main.zip",
-                  "https://github.com/defold/extension-crypt/archive/master.zip",
-                  "https://github.com/defold/extension-poco/archive/master.zip",
-                  "https://github.com/defold/extension-push/archive/master.zip",
-                  "https://github.com/defold/extension-review/archive/master.zip",
-                  "https://github.com/defold/extension-safearea/archive/master.zip",
-                  "https://github.com/defold/extension-siwa/archive/master.zip",
-                  "https://github.com/defold/extension-videoplayer-native/archive/master.zip",
-                  "https://github.com/defold/extension-webmonetization/archive/master.zip",
-                  "https://github.com/defold/extension-websocket/archive/master.zip",
-                  "https://github.com/defold/extension-webview/archive/master.zip",
-                  "https://github.com/defold/template-native-extension/archive/master.zip",
-                  "https://github.com/britzl/defold-screenshot/archive/master.zip",
-                  "https://github.com/britzl/defold-luasec/archive/master.zip",
-                  "https://github.com/britzl/defold-sharing/archive/master.zip",
-                  "https://github.com/AGulev/DefVideoAds/archive/master.zip",
-                  "https://github.com/subsoap/defos/archive/master.zip",
-                  "https://github.com/Lerg/extension-directories/archive/master.zip",
-                  "https://github.com/dapetcu21/defold-fmod/archive/master.zip",
-                  
-                  # Disabled until GA-SDK-DEFOLD supports both x86_64-osx and arm64-osx
-                  # https://github.com/GameAnalytics/GA-SDK-DEFOLD/issues/40
-                  # "https://github.com/GameAnalytics/GA-SDK-DEFOLD/archive/master.zip",
-                  
-                  # Bob.jar plugins:
-                  "https://github.com/defold/extension-lua-preprocessor/archive/refs/heads/main.zip",
-                  "https://github.com/defold/extension-prometheus/archive/refs/heads/master.zip",
-                  "https://github.com/defold/extension-resource-encryption/archive/refs/heads/master.zip"
-                ]
-        steps:
-            - uses: actions/checkout@v2
-
-            - uses: actions/setup-java@v3
-              with:
-                java-version: '17.0.5+8'
-                architecture: x64
-                distribution: 'temurin'
-
-            - name: Run tests (alpha)
-              run: ./run-tests.sh
-              env:
-                CHANNEL: "alpha"
-                BUILD_SERVER: "https://build-stage.defold.com"
-                PLATFORMS: "js-web,x86_64-win32,x86_64-linux,x86_64-macos,arm64-ios,armv7-android"
-                PROJECTS: ${{ matrix.projects }}
-            - name: Notify if tests failed
-              uses: homoluctus/slatify@master
-              if: failure()
-              with:
-                type: ${{ job.status }}
-                job_name: 'SDK tests (alpha)'
-                channel: '#defold-alarms-build'
-                url: ${{ secrets.SLACK_WEBHOOK }}
+  test:
+    uses: ./.github/workflows/test.yml
+    with:
+      channel: alpha
+    secrets:
+      slack_webhook: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/test-beta.yml
+++ b/.github/workflows/test-beta.yml
@@ -7,77 +7,9 @@ on:
     - cron: 0 6 * * *
 
 jobs:
-    test:
-        runs-on: ubuntu-latest
-        strategy:
-            max-parallel: 2
-            matrix:
-              projects: [
-                  "https://github.com/defold/extension-spine/archive/master.zip",
-                  #"https://github.com/defold/extension-rive/archive/master.zip",
-                  "https://github.com/defold/extension-adinfo/archive/master.zip",
-                  "https://github.com/defold/extension-admob/archive/master.zip",
-                  "https://github.com/defold/extension-camera/archive/master.zip",
-                  "https://github.com/defold/extension-facebook/archive/master.zip",
-                  "https://github.com/defold/extension-fbinstant/archive/master.zip",
-                  "https://github.com/defold/extension-firebase/archive/master.zip",
-                  "https://github.com/defold/extension-firebase-analytics/archive/master.zip",
-                  "https://github.com/defold/extension-firebase-remoteconfig/archive/master.zip",
-                  "https://github.com/defold/extension-googleplayinstant/archive/master.zip",
-                  "https://github.com/defold/extension-gpgs/archive/master.zip",
-                  "https://github.com/defold/extension-html5/archive/master.zip",
-                  "https://github.com/defold/extension-iac/archive/master.zip",
-                  "https://github.com/defold/extension-iap/archive/master.zip",
-                  "https://github.com/defold/extension-kaiads/archive/main.zip",
-                  "https://github.com/defold/extension-kaios/archive/main.zip",
-                  "https://github.com/defold/extension-crypt/archive/master.zip",
-                  "https://github.com/defold/extension-poco/archive/master.zip",
-                  "https://github.com/defold/extension-push/archive/master.zip",
-                  "https://github.com/defold/extension-review/archive/master.zip",
-                  "https://github.com/defold/extension-safearea/archive/master.zip",
-                  "https://github.com/defold/extension-siwa/archive/master.zip",
-                  "https://github.com/defold/extension-videoplayer-native/archive/master.zip",
-                  "https://github.com/defold/extension-webmonetization/archive/master.zip",
-                  "https://github.com/defold/extension-websocket/archive/master.zip",
-                  "https://github.com/defold/extension-webview/archive/master.zip",
-                  "https://github.com/defold/template-native-extension/archive/master.zip",
-                  "https://github.com/britzl/defold-screenshot/archive/master.zip",
-                  "https://github.com/britzl/defold-luasec/archive/master.zip",
-                  "https://github.com/britzl/defold-sharing/archive/master.zip",
-                  "https://github.com/AGulev/DefVideoAds/archive/master.zip",
-                  "https://github.com/subsoap/defos/archive/master.zip",
-                  "https://github.com/Lerg/extension-directories/archive/master.zip",
-                  "https://github.com/dapetcu21/defold-fmod/archive/master.zip",
-                  
-                  # Disabled until GA-SDK-DEFOLD supports both x86_64-osx and arm64-osx
-                  # https://github.com/GameAnalytics/GA-SDK-DEFOLD/issues/40
-                  # "https://github.com/GameAnalytics/GA-SDK-DEFOLD/archive/master.zip",
-                  
-                  # Bob.jar plugins:
-                  "https://github.com/defold/extension-lua-preprocessor/archive/refs/heads/main.zip",
-                  "https://github.com/defold/extension-prometheus/archive/refs/heads/master.zip",
-                  "https://github.com/defold/extension-resource-encryption/archive/refs/heads/master.zip"
-                ]
-        steps:
-            - uses: actions/checkout@v2
-            - uses: actions/setup-java@v3
-              with:
-                java-version: '17.0.5+8'
-                architecture: x64
-                distribution: 'temurin'
-
-            - name: Run tests (beta)
-              run: ./run-tests.sh
-              env:
-                CHANNEL: "beta"
-                BUILD_SERVER: "https://build-stage.defold.com"
-                PLATFORMS: "js-web,x86_64-win32,x86_64-linux,x86_64-macos,arm64-ios,armv7-android"
-                PROJECTS: ${{ matrix.projects }}
-            - name: Notify if tests failed
-              uses: homoluctus/slatify@master
-              if: failure()
-              with:
-                type: ${{ job.status }}
-                job_name: 'SDK tests (beta)'
-                channel: '#defold-alarms-build'
-                url: ${{ secrets.SLACK_WEBHOOK }}
+  test:
+    uses: ./.github/workflows/test.yml
+    with:
+      channel: beta
+    secrets:
+      slack_webhook: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/test-stable.yml
+++ b/.github/workflows/test-stable.yml
@@ -5,77 +5,9 @@ on:
     - cron: 0 11 * * *
 
 jobs:
-    test:
-        runs-on: ubuntu-latest
-        strategy:
-            max-parallel: 2
-            matrix:
-                projects: [
-                  "https://github.com/defold/extension-spine/archive/master.zip",
-                  #"https://github.com/defold/extension-rive/archive/master.zip",
-                  "https://github.com/defold/extension-adinfo/archive/master.zip",
-                  "https://github.com/defold/extension-admob/archive/master.zip",
-                  "https://github.com/defold/extension-camera/archive/master.zip",
-                  "https://github.com/defold/extension-facebook/archive/master.zip",
-                  "https://github.com/defold/extension-fbinstant/archive/master.zip",
-                  "https://github.com/defold/extension-firebase/archive/master.zip",
-                  "https://github.com/defold/extension-firebase-analytics/archive/master.zip",
-                  "https://github.com/defold/extension-firebase-remoteconfig/archive/master.zip",
-                  "https://github.com/defold/extension-googleplayinstant/archive/master.zip",
-                  "https://github.com/defold/extension-gpgs/archive/master.zip",
-                  "https://github.com/defold/extension-html5/archive/master.zip",
-                  "https://github.com/defold/extension-iac/archive/master.zip",
-                  "https://github.com/defold/extension-iap/archive/master.zip",
-                  "https://github.com/defold/extension-kaiads/archive/main.zip",
-                  "https://github.com/defold/extension-kaios/archive/main.zip",
-                  "https://github.com/defold/extension-crypt/archive/master.zip",
-                  "https://github.com/defold/extension-poco/archive/master.zip",
-                  "https://github.com/defold/extension-push/archive/master.zip",
-                  "https://github.com/defold/extension-review/archive/master.zip",
-                  "https://github.com/defold/extension-safearea/archive/master.zip",
-                  "https://github.com/defold/extension-siwa/archive/master.zip",
-                  "https://github.com/defold/extension-videoplayer-native/archive/master.zip",
-                  "https://github.com/defold/extension-webmonetization/archive/master.zip",
-                  "https://github.com/defold/extension-websocket/archive/master.zip",
-                  "https://github.com/defold/extension-webview/archive/master.zip",
-                  "https://github.com/defold/template-native-extension/archive/master.zip",
-                  "https://github.com/britzl/defold-screenshot/archive/master.zip",
-                  "https://github.com/britzl/defold-luasec/archive/master.zip",
-                  "https://github.com/britzl/defold-sharing/archive/master.zip",
-                  "https://github.com/AGulev/DefVideoAds/archive/master.zip",
-                  "https://github.com/subsoap/defos/archive/master.zip",
-                  "https://github.com/Lerg/extension-directories/archive/master.zip",
-                  "https://github.com/dapetcu21/defold-fmod/archive/master.zip",
-                  
-                  # Disabled until GA-SDK-DEFOLD supports both x86_64-osx and arm64-osx
-                  # https://github.com/GameAnalytics/GA-SDK-DEFOLD/issues/40
-                  # "https://github.com/GameAnalytics/GA-SDK-DEFOLD/archive/master.zip",
-                  
-                  # Bob.jar plugins:
-                  "https://github.com/defold/extension-lua-preprocessor/archive/refs/heads/main.zip",
-                  "https://github.com/defold/extension-prometheus/archive/refs/heads/master.zip",
-                  "https://github.com/defold/extension-resource-encryption/archive/refs/heads/master.zip"
-                ]
-        steps:
-            - uses: actions/checkout@v2
-            - uses: actions/setup-java@v3
-              with:
-                java-version: '17.0.5+8'
-                architecture: x64
-                distribution: 'temurin'
-
-            - name: Run tests (stable)
-              run: ./run-tests.sh
-              env:
-                CHANNEL: "stable"
-                BUILD_SERVER: "https://build-stage.defold.com"
-                PLATFORMS: "js-web,x86_64-win32,x86_64-linux,x86_64-macos,arm64-ios,armv7-android"
-                PROJECTS: ${{ matrix.projects }}
-            - name: Notify if tests failed
-              uses: homoluctus/slatify@master
-              if: failure()
-              with:
-                type: ${{ job.status }}
-                job_name: 'SDK tests (stable)'
-                channel: '#defold-alarms-build'
-                url: ${{ secrets.SLACK_WEBHOOK }}
+  test:
+    uses: ./.github/workflows/test.yml
+    with:
+      channel: stable
+    secrets:
+      slack_webhook: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,89 @@
+name: Reusable test workflow
+
+on:
+  workflow_call:
+    inputs:
+      channel:
+        required: true
+        type: string
+        description: 'Which Defold version use to build. Possible values: alpha, beta, stable'
+    secrets:
+      slack_webhook:
+        required: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      max-parallel: 2
+      matrix:
+        projects: [
+          'https://github.com/defold/extension-spine/archive/master.zip',
+          #'https://github.com/defold/extension-rive/archive/master.zip',
+          'https://github.com/defold/extension-adinfo/archive/master.zip',
+          'https://github.com/defold/extension-admob/archive/master.zip',
+          'https://github.com/defold/extension-camera/archive/master.zip',
+          'https://github.com/defold/extension-facebook/archive/master.zip',
+          'https://github.com/defold/extension-fbinstant/archive/master.zip',
+          'https://github.com/defold/extension-firebase/archive/master.zip',
+          'https://github.com/defold/extension-firebase-analytics/archive/master.zip',
+          'https://github.com/defold/extension-firebase-remoteconfig/archive/master.zip',
+          'https://github.com/defold/extension-googleplayinstant/archive/master.zip',
+          'https://github.com/defold/extension-gpgs/archive/master.zip',
+          'https://github.com/defold/extension-html5/archive/master.zip',
+          'https://github.com/defold/extension-iac/archive/master.zip',
+          'https://github.com/defold/extension-iap/archive/master.zip',
+          'https://github.com/defold/extension-kaiads/archive/main.zip',
+          'https://github.com/defold/extension-kaios/archive/main.zip',
+          'https://github.com/defold/extension-crypt/archive/master.zip',
+          'https://github.com/defold/extension-poco/archive/master.zip',
+          'https://github.com/defold/extension-push/archive/master.zip',
+          'https://github.com/defold/extension-review/archive/master.zip',
+          'https://github.com/defold/extension-safearea/archive/master.zip',
+          'https://github.com/defold/extension-siwa/archive/master.zip',
+          'https://github.com/defold/extension-videoplayer-native/archive/master.zip',
+          'https://github.com/defold/extension-webmonetization/archive/master.zip',
+          'https://github.com/defold/extension-websocket/archive/master.zip',
+          'https://github.com/defold/extension-webview/archive/master.zip',
+          'https://github.com/defold/template-native-extension/archive/master.zip',
+          'https://github.com/britzl/defold-screenshot/archive/master.zip',
+          'https://github.com/britzl/defold-luasec/archive/master.zip',
+          'https://github.com/britzl/defold-sharing/archive/master.zip',
+          'https://github.com/AGulev/DefVideoAds/archive/master.zip',
+          'https://github.com/subsoap/defos/archive/master.zip',
+          'https://github.com/Lerg/extension-directories/archive/master.zip',
+          'https://github.com/dapetcu21/defold-fmod/archive/master.zip',
+                    
+          # Disabled until GA-SDK-DEFOLD supports both x86_64-osx and arm64-osx
+          # https://github.com/GameAnalytics/GA-SDK-DEFOLD/issues/40
+          #'https://github.com/GameAnalytics/GA-SDK-DEFOLD/archive/master.zip',
+                    
+          # Bob.jar plugins:
+          'https://github.com/defold/extension-lua-preprocessor/archive/refs/heads/main.zip',
+          'https://github.com/defold/extension-prometheus/archive/refs/heads/master.zip',
+          'https://github.com/defold/extension-resource-encryption/archive/refs/heads/master.zip'
+        ]
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+      - uses: actions/setup-java@387ac29b308b003ca37ba93a6cab5eb57c8f5f93
+        with:
+          java-version: '17.0.5+8'
+          architecture: x64
+          distribution: 'temurin'
+
+      - name: Run tests ${{ inputs.channel }}
+        run: ./run-tests.sh
+        env:
+          CHANNEL: ${{ inputs.channel }}
+          BUILD_SERVER: 'https://build-stage.defold.com'
+          PLATFORMS: 'js-web,x86_64-win32,x86_64-linux,x86_64-macos,arm64-macos,arm64-ios,armv7-android'
+          PROJECTS: ${{ matrix.projects }}
+      - name: Notify if tests failed
+        if: failure()  
+        uses: homoluctus/slatify@c4847b8c84e3e8076fd3c42cc00517a10426ed65
+        with:
+          type: ${{ job.status }}
+          job_name: 'SDK tests ${{ inputs.channel }}'
+          channel: '#defold-alarms-build'
+          url: ${{ secrets.slack_webhook }}


### PR DESCRIPTION
* Add reusable workflow to avoid code duplication
* Add `arm64-macos` platform to list of `PLATFORMS`
* Add fail-fast: false to enable complete build of all extension. I guess it's better to collect all issues with extension compiling at once rather than fix and compile one-by-one.
* Add dependabot configuration to follow github actions update
* Update github actions version to eliminate warning about old nodejs runtime
* Pin gh actions version (according to advise from https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions)

Example how it runs (without arm64-macos) https://github.com/ekharkunov/test-sdk/actions/runs/7651914447/job/20850637534

P.S. Warning about homoluctus/slatify is still presented. I'll fix it in separate PR.